### PR TITLE
Fix white space at top and bottom of app

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,9 +39,11 @@ export default {
   background-color: #ece5db;
   color: #35312D;
   font-family: 'Avenir', Helvetica, Arial, sans-serif;
-  margin: 0;
+  height: fit-content;
   overflow: hidden;
   padding: 16px;
+  position: absolute;
+  top: 0; bottom: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
- Set app position to absolute; bottom and top properties have values of 0
- Set app height to 'fit-content'